### PR TITLE
Team ID missing when user submits expense integrity error 

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -6,8 +6,10 @@ from django.forms import (
     HiddenInput, ModelChoiceField, TextInput,
     DecimalField, NumberInput, ImageField, FileInput
 )
-from core.models import Employee, Expense, ProjectEmployeeAllocatedBudget, \
-    ExpenseType, Team
+from core.models import (
+    Employee, Expense, ExpenseType,
+    ProjectEmployeeAllocatedBudget, Team
+)
 from django import forms
 from .models import FundRequest
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -7,7 +7,7 @@ from django.forms import (
     DecimalField, NumberInput, ImageField, FileInput
 )
 from core.models import Employee, Expense, ProjectEmployeeAllocatedBudget, \
-    ExpenseType
+    ExpenseType, Team
 from django import forms
 from .models import FundRequest
 
@@ -87,6 +87,10 @@ class ExpenseForm(ModelForm):
         queryset=Employee.objects.all(),
         widget=HiddenInput()
     )
+    team = ModelChoiceField(
+        queryset=Team.objects.all(),
+        widget=HiddenInput()
+    )
     description = CharField(
         label='Description',
         max_length=100,
@@ -106,9 +110,7 @@ class ExpenseForm(ModelForm):
 
          queryset=ExpenseType.objects.all(),
         widget=forms.Select(attrs={
-            'class': "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
-        })
-    )
+            'class': "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outl
 
     upload = ImageField(
         label='Upload',
@@ -119,7 +121,7 @@ class ExpenseForm(ModelForm):
 
     class Meta:
         model = Expense
-        fields = ['employee', 'description', 'initial_amount', 'upload', 'type']
+        fields = ['employee', 'description', 'initial_amount', 'upload', 'type', 'team']
 
     def clean_initial_amount(self):
         employee = self.cleaned_data["employee"]

--- a/core/forms.py
+++ b/core/forms.py
@@ -107,10 +107,11 @@ class ExpenseForm(ModelForm):
     )
 
     type = forms.ModelChoiceField(
-
-         queryset=ExpenseType.objects.all(),
+        queryset=ExpenseType.objects.all(),
         widget=forms.Select(attrs={
-            'class': "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outl
+            'class': "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+        })
+    )
 
     upload = ImageField(
         label='Upload',

--- a/core/models.py
+++ b/core/models.py
@@ -7,7 +7,6 @@ class Employee(AbstractUser):
     account_number = models.CharField(max_length=10, unique=True, null=True)
     avatar = models.ImageField(upload_to='avatars/', default='avatars/default.png')
     team = models.ForeignKey("Team", null=True, on_delete=models.PROTECT, blank=True )
-
 class Project(models.Model):
     description = models.CharField(max_length=150)
     name = models.CharField(max_length=50)

--- a/core/templates/expense_form.html
+++ b/core/templates/expense_form.html
@@ -59,11 +59,14 @@
                         {{ form.type }}
                         <div class="text-red-500 text-sm">{{ form.type.errors }}</div>
                     </div>
-
+                    <!-- Hidden Team Field -->
+                     <div hidden>
+                        {{ form.team }}
+                    </div>
                     <!-- Upload Receipt -->
                     <div>
                         <label class="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">
-                            Upload Receipt
+                            Upload Receipt (required)
                         </label>
                         {{ form.upload }}
                         <div class="text-red-500 text-sm">{{ form.upload.errors }}</div>

--- a/core/views.py
+++ b/core/views.py
@@ -289,8 +289,9 @@ def expense_form(request):
             print(form.errors)
     else:
         form = ExpenseForm(initial={
-            "employee": request.user
 
+            "employee": request.user,
+            "team": request.user.team
         })
 
     # For GET request


### PR DESCRIPTION
* fix - integrity error was being triggered when user submitted a new expense - the team ID was missing from the information being sent to the back/database. 